### PR TITLE
Ignore anything in bin and set target ruby version

### DIFF
--- a/source/.rubocop.yml
+++ b/source/.rubocop.yml
@@ -1,7 +1,9 @@
 AllCops:
+  TargetRubyVersion: 2.2
   Exclude:
     # Rubocop is accidentally linting HTML ERB files in Atom Editor https://github.com/AtomLinter/linter-rubocop/issues/48
     - '**/*.html.erb'
+    - '**/bin/*'
 
 inherit_from:
   - rubocop/gds-ruby-styleguide.yml


### PR DESCRIPTION
Rubocop stumbled on named arguments so I had to set TargetRubyVersion to 2.2
It was also trying its luck on e.g. 'bin/setup' so I put a stop to that.