### PR TITLE
Add license details to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,19 @@ to [rubygems.org](https://rubygems.org).
 
 Bug reports and pull requests are welcome on GitHub at
 https://github.com/reggieb/before_commit.
+
+## License
+
+THIS INFORMATION IS LICENSED UNDER THE CONDITIONS OF THE OPEN GOVERNMENT LICENCE found at:
+
+http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3
+
+The following attribution statement MUST be cited in your products and applications when using this information.
+
+> Contains public sector information licensed under the Open Government license v3
+
+### About the license
+
+The Open Government Licence (OGL) was developed by the Controller of Her Majesty's Stationery Office (HMSO) to enable information providers in the public sector to license the use and re-use of their information under a common open licence.
+
+It is designed to encourage use and re-use of information freely and flexibly, with only a few conditions.


### PR DESCRIPTION
This details adds an overview and explanation of the license used by this repo (OGL) as per the standard convention for Environment Agency public repositories.