### PR TITLE
Stop Travis-ci building twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,12 @@ language: ruby
 rvm:
   - 2.2.3
 before_install: gem install bundler -v 1.11.2
+
+# Have this option to stop travis-ci building twice. Currently we have travis set to build both
+# PR's and pushes. However this means when we push to a PR we have to wait for Travis to finish
+# 2 builds. If we unticked 'pushes' when the PR was finally merged that would not be built. The
+# brute force approach would be to untick build PR's and just build all pushes. We instead have
+# gone with the approach outlined here http://stackoverflow.com/a/31882307
+branches:
+  only:
+    - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: ruby
+cache: bundler
+
 rvm:
   - 2.2.3
+
 before_install: gem install bundler -v 1.11.2
 
 # Have this option to stop travis-ci building twice. Currently we have travis set to build both


### PR DESCRIPTION
Currently we have travis set to build both PR's and pushes. However this means when we push to a PR we have to wait for Travis to finish 2 builds.

If we unticked 'pushes' when the PR was finally merged that would not be built. The brute force approach would be to untick build PR's and just build all pushes. We instead have gone with the approach outlined here http://stackoverflow.com/a/31882307