### PR TITLE
Update contribution section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,11 @@ run `bundle exec rake release`, which will create a git tag for the version,
 push git commits and tags, and push the `.gem` file
 to [rubygems.org](https://rubygems.org).
 
-## Contributing
+## Contributing to this project
 
-Bug reports and pull requests are welcome on GitHub at
-https://github.com/reggieb/before_commit.
+If you have an idea you'd like to contribute please log an issue.
+
+All contributions should be submitted via a pull request.
 
 ## License
 


### PR DESCRIPTION
This change brings the contribution section of the README inline with other Environment Agency public projects. Essentially we tell people to create issues for things they'd like to see changed, else submit PR's if they have done the work and the team responsible will get back to them within best endeavours.