### PR TITLE
Add the Travis-CI build badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # BeforeCommit
 
+[![Build Status](https://travis-ci.org/EnvironmentAgency/before_commit.svg?branch=master)](https://travis-ci.org/EnvironmentAgency/before_commit)
+
 A utility to provide a common set of definitions for code quality utilities
 (for example, overcommit, rubocop, scss_lint and brakeman) across multiple
 projects.


### PR DESCRIPTION
Simply adds a badge to the README that indicates the status of the build on Travis-CI, the CI service we are using for this gem.