### PR TITLE
Skip brakeman tests unless bin/rails is detected.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ spec = Gem::Specification.find_by_name 'before_commit'
 load "#{spec.gem_dir}/lib/tasks/before_commit.rake"
 ```
 
+Note that if bin/rails is not detected, the brakeman test will be skipped.
+However, as there isn't a way to skip in overcommit, brakeman shows as PASSED
+even though the test has not run. 
+
 ### Checks
 
 The checks are defined in `config/config.yml`. If the command defined in a

--- a/lib/before_commit/version.rb
+++ b/lib/before_commit/version.rb
@@ -1,3 +1,3 @@
 module BeforeCommit
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end

--- a/source/.git-hooks/pre_commit/brakeman.rb
+++ b/source/.git-hooks/pre_commit/brakeman.rb
@@ -1,0 +1,14 @@
+module Overcommit::Hook::PreCommit
+  # Runs `brakeman` against any modified Ruby/Rails files.
+  #
+  # @see http://brakemanscanner.org/
+  class Brakeman < Base
+    def run
+      return :pass unless File.exist?('bin/rails') # There doesn't appear to be a :skip option
+      result = execute(command + [applicable_files.join(',')])
+      return :pass if result.success?
+
+      [:fail, result.stdout]
+    end
+  end
+end


### PR DESCRIPTION
This fixes issue https://github.com/EnvironmentAgency/before_commit/issues/2

That is, if bin/rails is not found, the brakeman test is skipped.

